### PR TITLE
Mitigations for KVM performance issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,6 +162,25 @@ runs:
         fi
         echo "RUST_BACKTRACE=full" >> $GITHUB_ENV
       shell: bash
+    # see https://github.com/firecracker-microvm/firecracker/blob/c75c86103d464f61851134eb3211b35323be4ffc/docs/prod-host-setup.md#linux-61-boot-time-regressions
+    - name: Apply perf fixes for KVM on kernel 6.x
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        if command -v apt > /dev/null 2>&1; then
+          kernel_version=$(uname -r)
+          if [[ "$kernel_version" == 6.* ]]; then
+            if [[ $(cat /sys/devices/system/cpu/vulnerabilities/itlb_multihit) == "Not affected" ]]; then
+              KVM_VENDOR_MOD=$(lsmod |grep -P "^kvm_(amd|intel)" | awk '{print $1}')
+              sudo modprobe -r $KVM_VENDOR_MOD kvm
+              sudo modprobe kvm nx_huge_pages=never
+              sudo modprobe $KVM_VENDOR_MOD
+            fi
+            if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+              sudo mount -o remount,favordynmods /sys/fs/cgroup
+            fi
+          fi
+        fi
+      shell: bash
 
     ### Windows setup ###
 


### PR DESCRIPTION
https://github.com/hyperlight-dev/hyperlight/issues/47 describes a performance issue with KVM when using kernel version 6.x.

This PR applies the mitigations for that issue described [here](https://github.com/firecracker-microvm/firecracker/blob/c75c86103d464f61851134eb3211b35323be4ffc/docs/prod-host-setup.md#linux-61-boot-time-regressions) to KVM runners.