### PR TITLE
Partial revert of #4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,8 +146,16 @@ runs:
     - name: Set up env vars (Linux)
       if: ${{ (runner.os == 'Linux') }}
       run: |
-        if [ -e /dev/kvm ]; then
-          sudo adduser $(whoami) kvm
+        set -x
+        if command -v dnf > /dev/null 2>&1; then
+          echo "Detected mariner / hyperv"
+          ls -al /dev/mshv
+          whoami
+        else
+          echo "Detected Ubuntu / kvm"
+          sudo ls -al /dev/kvm
+          sudo chgrp $(whoami) /dev/kvm
+          sudo ls -al /dev/kvm
         fi
         echo "RUST_BACKTRACE=full" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
Partial revert of #4 

Jobs started failing with 

>called `Result::unwrap()` on an `Err` value: Error("No Hypervisor was found for Sandbox, Hypervisor Handler Message Receive Timedout")

After we started using release v1.3.0 of the action