### PR TITLE
Remove chgrp on /dev/kvm

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -162,6 +162,7 @@ runs:
           sudo ls -al /dev/kvm
         fi
         whoami
+        groups
         echo "RUST_BACKTRACE=full" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
This is not needed since we now assign cloudtest to kvm group during provisioning (and it no longer works since the ownership and permissions on /dev/kvm get reset during GH workflow execution causing jobs to fail)