### PR TITLE
Update runner os to latest ubuntu

### DIFF
--- a/.github/workflows/CreateReleaseBranch.yml
+++ b/.github/workflows/CreateReleaseBranch.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   create-branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest Ubuntu version for the `create-branch` job.

* [`.github/workflows/CreateReleaseBranch.yml`](diffhunk://#diff-5a65017dd555239cdec5b831959ff61bb29a02e8ea578ebb8dcf148e0d857c7fL17-R17): Changed the `runs-on` property from `ubuntu-20.04` to `ubuntu-latest` to ensure the job always uses the most up-to-date Ubuntu environment.